### PR TITLE
debuggin authService

### DIFF
--- a/src/app/nav-bar/nav-bar.component.ts
+++ b/src/app/nav-bar/nav-bar.component.ts
@@ -17,14 +17,13 @@ export class NavBarComponent implements OnInit {
 
   constructor(private router: Router,
               private renderer: Renderer2,
-              private authService: AuthService,
               private el: ElementRef) {}
 
   ngOnInit(): void {
 
-    this.authService.isLoggedIn.subscribe((isLoggedIn: boolean) => {
-      this.isLoggedIn = isLoggedIn;
-    });
+    // this.authService.isLoggedIn.subscribe((isLoggedIn: boolean) => {
+    //   this.isLoggedIn = isLoggedIn;
+    // });
 
     const overlay = this.el.nativeElement.querySelector('#overlay');
     const openModal = this.el.nativeElement.querySelectorAll('.open_modal');
@@ -61,7 +60,7 @@ export class NavBarComponent implements OnInit {
   }
 
   onLogout() {
-    this.authService.logout();
+    // this.authService.logout();
   }
 
 }


### PR DESCRIPTION
I am still looking for a solution, getting errors in the ng server.


./node_modules/@mongodb-js/zstd/index.js:31:28-65 - Warning: Module not found: Error: Can't resolve './zstd.win32-x64-msvc.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:49:28-61 - Warning: Module not found: Error: Can't resolve './zstd.darwin-x64.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:51:28-66 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-darwin-x64' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:61:28-63 - Warning: Module not found: Error: Can't resolve './zstd.darwin-arm64.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:63:28-68 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-darwin-arm64' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:80:30-67 - Warning: Module not found: Error: Can't resolve './zstd.linux-x64-musl.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:82:30-72 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-linux-x64-musl' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:91:30-66 - Warning: Module not found: Error: Can't resolve './zstd.linux-x64-gnu.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.jsm:93:30-71 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-linux-x64-gnu' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:105:30-69 - Warning: Module not found: Error: Can't resolve './zstd.linux-arm64-musl.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:107:30-74 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-linux-arm64-musl' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:116:30-68 - Warning: Module not found: Error: Can't resolve './zstd.linux-arm64-gnu.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:118:30-73 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-linux-arm64-gnu' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:129:28-70 - Warning: Module not found: Error: Can't resolve './zstd.linux-arm-gnueabihf.node' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:131:28-75 - Warning: Module not found: Error: Can't resolve '@mongodb-js/zstd-linux-arm-gnueabihf' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/bcryptjs/dist/bcrypt.js:64:13-45 - Warning: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\bcryptjs\dist'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/utils.js:1010:32-87 - Warning: Critical dependency: the request of a dependency is an expression

./node_modules/snappy/index.js:1:569-607 - Warning: Module not found: Error: Can't resolve './snappy.android-arm64.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:622-662 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-android-arm64' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:811-852 - Warning: Module not found: Error: Can't resolve './snappy.android-arm-eabi.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:867-910 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-android-arm-eabi' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1159-1198 - Warning: Module not found: Error: Can't resolve './snappy.win32-x64-msvc.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1403-1443 - Warning: Module not found: Error: Can't resolve './snappy.win32-ia32-msvc.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1458-1500 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-win32-ia32-msvc' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1651-1692 - Warning: Module not found: Error: Can't resolve './snappy.win32-arm64-msvc.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1707-1750 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-win32-arm64-msvc' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:1997-2032 - Warning: Module not found: Error: Can't resolve './snappy.darwin-x64.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2047-2084 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-darwin-x64' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2231-2268 - Warning: Module not found: Error: Can't resolve './snappy.darwin-arm64.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2283-2322 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-darwin-arm64' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2626-2662 - Warning: Module not found: Error: Can't resolve './snappy.freebsd-x64.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2677-2715 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-freebsd-x64' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2900-2939 - Warning: Module not found: Error: Can't resolve './snappy.linux-x64-musl.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:2954-2995 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-linux-x64-musl' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3131-3169 - Warning: Module not found: Error: Can't resolve './snappy.linux-x64-gnu.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3184-3224 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-linux-x64-gnu' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3389-3430 - Warning: Module not found: Error: Can't resolve './snappy.linux-arm64-musl.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3445-3488 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-linux-arm64-musl' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3626-3666 - Warning: Module not found: Error: Can't resolve './snappy.linux-arm64-gnu.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3681-3723 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-linux-arm64-gnu' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3876-3920 - Warning: Module not found: Error: Can't resolve './snappy.linux-arm-gnueabihf.node' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:3935-3981 - Warning: Module not found: Error: Can't resolve '@napi-rs/snappy-linux-arm-gnueabihf' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/bson/lib/bson.cjs:99:15-44 - Warning: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\bson\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }



./node_modules/@mongodb-js/zstd/index.js:1:37-50 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

./node_modules/@mongodb-js/zstd/index.js:2:17-32 - Error: Module not found: Error: Can't resolve 'path' in 'D:\JavaScript\Portfolio\node_modules\@mongodb-js\zstd'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }

./node_modules/aws4/aws4.js:2:10-24 - Error: Module not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\aws4'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/aws4/aws4.js:3:18-40 - Error: Module not found: Error: Can't resolve 'querystring' in 'D:\JavaScript\Portfolio\node_modules\aws4'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "querystring": require.resolve("querystring-es3") }'
        - install 'querystring-es3'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "querystring": false }

./node_modules/aws4/aws4.js:4:13-30 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\aws4'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/bindings/bindings.js:5:9-22 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\bindings'

./node_modules/bindings/bindings.js:6:9-24 - Error: Module not found: Error: Can't resolve 'path' in 'D:\JavaScript\Portfolio\node_modules\bindings'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }

./node_modules/file-uri-to-path/index.js:6:10-29 - Error: Module not found: Error: Can't resolve 'path' in 'D:\JavaScript\Portfolio\node_modules\file-uri-to-path'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }

./node_modules/gaxios/build/src/gaxios.js:26:16-32 - Error: Module not found: Error: Can't resolve 'https' in 'D:\JavaScript\Portfolio\node_modules\gaxios\build\src'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "https": require.resolve("https-browserify") }'
        - install 'https-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "https": false }

./node_modules/gaxios/build/src/gaxios.js:28:38-60 - Error: Module not found: Error: Can't resolve 'querystring' in 'D:\JavaScript\Portfolio\node_modules\gaxios\build\src'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "querystring": require.resolve("querystring-es3") }'
        - install 'querystring-es3'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "querystring": false }

./node_modules/gaxios/build/src/gaxios.js:30:14-28 - Error: Module not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\gaxios\build\src'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/gcp-metadata/build/src/gcp-residency.js:19:13-26 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\gcp-metadata\build\src'

./node_modules/gcp-metadata/build/src/gcp-residency.js:20:13-26 - Error: Module not found: Error: Can't resolve 'os' in 'D:\JavaScript\Portfolio\node_modules\gcp-metadata\build\src'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "os": require.resolve("os-browserify/browser") }'
        - install 'os-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "os": false }

./node_modules/https-proxy-agent/dist/agent.js:15:30-44 - Error: Module not found: Error: Can't resolve 'net' in 'D:\JavaScript\Portfolio\node_modules\https-proxy-agent\dist'

./node_modules/https-proxy-agent/dist/agent.js:16:30-44 - Error: Module not found: Error: Can't resolve 'tls' in 'D:\JavaScript\Portfolio\node_modules\https-proxy-agent\dist'

./node_modules/https-proxy-agent/dist/agent.js:17:30-44 - Error: 9mModule not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\https-proxy-agent\dist'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/https-proxy-agent/dist/agent.js:18:33-50 - Error: Module not found: Error: Can't resolve 'assert' in 'D:\JavaScript\Portfolio\node_modules\https-proxy-agent\dist'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "assert": require.resolve("assert/") }'
        - install 'assert'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "assert": false }

./node_modules/jsonwebtoken/sign.js:6:57-74 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\jsonwebtoken'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/jsonwebtoken/verify.js:13:4-2139m - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\jsonwebtoken'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/jwa/index.js:3:13-30 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\jwa'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/jwa/index.js:5:11-26 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\jwa'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/jws/lib/data-stream.js:3:13-30 - [0mError: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/jws/lib/data-stream.js:4:11-26 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/jws/lib/sign-stream.js:5:13-30 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/jws/lib/sign-stream.js:7:11-26[39m - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/jws/lib/verify-stream.js:5:13-30 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/jws/lib/verify-stream.js:7:11-26 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\jws\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/kerberos/lib/auth_processes/mongodb.js:2:12-26 - Error: Module not found: Error: Can't resolve 'dns' in 'D:\JavaScript\Portfolio\node_modules\kerberos\lib\auth_processes'

./node_modules/mongodb-client-encryption/lib/clientEncryption.js:23:6-21 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb-client-encryption/lib/cryptoCallbacks.js:2:15-32 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb-client-encryption/lib/mongocryptdManager.js:3:14-44 - Error: Module not found: Error: Can't resolve 'child_process' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

./node_modules/mongodb-client-encryption/lib/stateMachine.js:6:4-19 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb-client-encryption/lib/stateMachine.js:8:14-28 - Error: Module not found: Error: Can't resolve 'tls' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

./node_modules/mongodb-client-encryption/lib/stateMachine.js:9:14-28 - Error: Module not found: Error: Can't resolve 'net' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

./node_modules/mongodb-client-encryption/lib/stateMachine.js:10:13-26 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\mongodb-client-encryption\lib'

./node_modules/mongodb/lib/cmap/auth/gssapi.js:4:12-26 - Error: Module not found: Error: Can't resolve 'dns' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

./node_modules/mongodb/lib/cmap/auth/mongocr.js:4:15-32 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/cmap/auth/mongodb_aws.js:4:15-32 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/cmap/auth/mongodb_aws.js:5:13-28 - Error: Module not found: Error: Can't resolve 'http' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "http": require.resolve("stream-http") }'
        - install 'stream-http'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "http": false }

./node_modules/mongodb/lib/cmap/auth/mongodb_aws.js:6:12-26 - Error: Module not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/mongodb/lib/cmap/auth/scram.js:4:15-32 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\auth'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/cmap/connect.js:4:12-26 - Error: Module not found: Error: Can't resolve 'net' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap'

./node_modules/mongodb/lib/cmap/connect.js:6:12-26 - Error: Module not found: Error: Can't resolve 'tls' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap'

./node_modules/mongodb/lib/cmap/connection.js:4:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/cmap/connection_pool.js:4:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/cmap/message_stream.js:4:17-34 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/mongodb/lib/cmap/wire_protocol/compression.js:8:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\wire_protocol'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/cmap/wire_protocol/compression.js:9:13-28 - Error: Module not found: Error: Can't resolve 'zlib' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cmap\wire_protocol'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "zlib": require.resolve("browserify-zlib") }'
        - install 'browserify-zlib'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "zlib": false }

./node_modules/mongodb/lib/connection_string.js:8:12-26 - Error: Module not found: Error: Can't resolve 'dns' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

./node_modules/mongodb/lib/connection_string.js:9:11-24 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

./node_modules/mongodb/lib/connection_string.js:11:14-28 - Error: Module not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/mongodb/lib/cursor/abstract_cursor.js:11:17-34 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cursor'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/mongodb/lib/cursor/abstract_cursor.js:12:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\cursor'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/gridfs/download.js:8:17-34 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\gridfs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/mongodb/lib/gridfs/upload.js:8:17-34 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\gridfs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/mongodb/lib/mongo_client.js:8:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/mongo_logger.js:4:17-34 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/mongodb/lib/operations/add_user.js:4:15-32 - Error: Module not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\operations'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/operations/operation.js:4:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\operations'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/sdam/common.js:4:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/sdam/monitor.js:4:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/sdam/srv_polling.js:8:12-26 - Error: Module not found: Error: Can't resolve 'dns' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

./node_modules/mongodb/lib/sdam/srv_polling.js:9:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/sdam/topology.js:4:17-34 - Error: Module not found: Error: Can't resolve 'timers' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "timers": require.resolve("timers-browserify") }'
        - install 'timers-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "timers": false }

./node_modules/mongodb/lib/sdam/topology.js:5:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib\sdam'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/sessions.js:9:15-30 - Error: Module not found: Error: Can't resolve 'util' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
        - install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "util": false }

./node_modules/mongodb/lib/utils.js:7:15-32 - Error: [0mModule not found: Error: Can't resolve 'crypto' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }

./node_modules/mongodb/lib/utils.js:8:11-24 - Error: Module not found: Error: Can't resolve 'os' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "os": require.resolve("os-browserify/browser") }'
        - install 'os-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "os": false }

./node_modules/mongodb/lib/utils.js:9:14-28 - Error: Module not found: Error: Can't resolve 'url' in 'D:\JavaScript\Portfolio\node_modules\mongodb\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }

./node_modules/saslprep/lib/memory-code-points.js:3:11-24 - 1mError: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\saslprep\lib'

./node_modules/saslprep/lib/memory-code-points.js:4:13-28 - Error: Module not found: Error: Can't resolve 'path' in 'D:\JavaScript\Portfolio\node_modules\saslprep\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }

./node_modules/snappy/index.js:1:44-57 - Error: Module not found: Error: Can't resolve 'fs' in 'D:\JavaScript\Portfolio\node_modules\snappy'

./node_modules/snappy/index.js:1:65-80 - Error: Module not found: Error: Can't resolve 'path' in 'D:\JavaScript\Portfolio\node_modules\snappy'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }

./node_modules/socks/build/client/socksclient.js:35:12-26 - Error: Module not found: Error: Can't resolve 'net' in 'D:\JavaScript\Portfolio\node_modules\socks\build\client'

./node_modules/socks/build/common/helpers.js:6:15-32 - Error: Module not found: Error: Can't resolve 'stream' in 'D:\JavaScript\Portfolio\node_modules\socks\build\common'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }

./node_modules/socks/node_modules/ip/lib/ip.js:3:11-24 - Error: Module not found: Error: Can't resolve 'os' in 'D:\JavaScript\Portfolio\node_modules\socks\node_modules\ip\lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "os": require.resolve("os-browserify/browser") }'
        - install 'os-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "os": false }

./node_modules/@mongodb-js/zstd-win32-x64-msvc/zstd.win32-x64-msvc.node:1:2 - Error: Module parse failed: Unexpected character '�' (1:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)

./node_modules/@napi-rs/snappy-win32-x64-msvc/snappy.win32-x64-msvc.node:1:2 - Error: Module parse failed: Unexpected character '�' (1:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)



× Failed to compile.